### PR TITLE
Fix gamma correction

### DIFF
--- a/egui-d3d11/src/shader/shader.hlsl
+++ b/egui-d3d11/src/shader/shader.hlsl
@@ -23,5 +23,8 @@ sampler sampler0;
 Texture2D texture0;
 
 float4 ps_main(vs_out input) : SV_TARGET {
-  return pow(input.color, 1.0 / 2.2) * texture0.Sample(sampler0, input.uv);
+  float4 output = pow(input.color, 1.0 / 2.2);
+  // keep the alpha channel intact, we shouldn't gamma correct it
+  output[3] = input.color[3];
+  return output * texture0.Sample(sampler0, input.uv);
 }


### PR DESCRIPTION
Currently, the gamma correction code is wrong, and gamma-corrects the alpha channel. This results in transparent things like shadows being way less transparent than they should be. This patch simply persists the alpha channel through the gamma correction.

Before:
![](https://i.imgur.com/cel1ePK.png)

After:
![](https://i.imgur.com/GGDXhhY.png)

This now aligns with how the official egui demo renders windows.