### PR TITLE
fix: panic when shaders or index buffer was `None`

### DIFF
--- a/egui-d3d11/src/backup.rs
+++ b/egui-d3d11/src/backup.rs
@@ -190,7 +190,7 @@ impl InnerState {
             ),
         );
         ctx.PSSetShader(
-            &expect!(self.pixel_shader.take(), "Failed to set pixel shader"),
+            self.pixel_shader.take().as_ref(),
             Some(
                 &self
                     .pixel_shader_instances
@@ -203,7 +203,7 @@ impl InnerState {
         self.pixel_shader_instances.release();
 
         ctx.VSSetShader(
-            &expect!(self.vertex_shader.take(), "Failed to set vertex shader"),
+            self.vertex_shader.take().as_ref(),
             Some(
                 &self
                     .vertex_shader_instances
@@ -238,7 +238,7 @@ impl InnerState {
         ctx.VSSetConstantBuffers(0, Some(&constant_buffers));
         ctx.IASetPrimitiveTopology(self.primitive_topology);
         ctx.IASetIndexBuffer(
-            &expect!(self.index_buffer.take(), "Failed to set index buffer"),
+            self.index_buffer.take().as_ref(),
             self.index_buffer_format,
             self.index_buffer_offest,
         );


### PR DESCRIPTION
Hi,

So when the previous DX state is backed up, the pixel and vertex shaders, aswell as the index buffer might be `None` (`null`), and taking and expecting a value causes a panic. Afaik the "correct" behavior here is to just pass `None` aka `nullptr` to these functions when restoring, and making sure that they are dropped and dereferenced/released.
I looked at ImGui [dxd11 hooks](https://github.com/Sh0ckFR/Universal-ImGui-D3D11-Hook/blob/e28e54508162fab4cb449d61ec4b1db6e0519e06/imgui_impl_dx11.cpp#L217-L233), and that is exactly what they do aswell.

the commit name might be really bad, sorry about that.
